### PR TITLE
Update Icelandic translation for nonce verification

### DIFF
--- a/languages/straumur-payments-for-woocommerce-is_IS.po
+++ b/languages/straumur-payments-for-woocommerce-is_IS.po
@@ -102,7 +102,7 @@ msgstr "Greiðsluvilla:  Tókst ekki að setja upp greiðslulotu."
 
 #: includes/class-wc-straumur-payment-gateway.php:453
 msgid "Nonce verification failed."
-msgstr "Nonce staðfesting tókst ekki."
+msgstr "Staðfesting öryggiskóða tókst ekki."
 
 #: includes/class-wc-straumur-payment-gateway.php:510
 msgid "Your payment session was not completed. Please try again."


### PR DESCRIPTION
This pull request updates the Icelandic translation for a payment gateway error message to use a more accurate and user-friendly term for "Nonce verification failed."

- Localization improvement:
  * Updated the translation of "Nonce verification failed." in `languages/straumur-payments-for-woocommerce-is_IS.po` to use "Staðfesting öryggiskóða tókst ekki." for better clarity and accuracy.Revised the translation of 'Nonce verification failed.' in the Icelandic language file to improve clarity and accuracy.