### PR TITLE
fix: code quality improvements and apply PR#38 refactor

### DIFF
--- a/includes/class-wc-straumur-api.php
+++ b/includes/class-wc-straumur-api.php
@@ -36,13 +36,6 @@ use function wp_json_encode;
 class WC_Straumur_API {
 
 	/**
-	 * Holds the singleton instance.
-	 *
-	 * @var WC_Straumur_API|null
-	 */
-	private static $instance = null;
-
-	/**
 	 * API key for authentication.
 	 *
 	 * @var string
@@ -127,18 +120,6 @@ class WC_Straumur_API {
 	 * @var float
 	 */
 	private $checkout_expiry;
-
-	/**
-	 * Get the singleton instance.
-	 *
-	 * @return WC_Straumur_API
-	 */
-	public static function instance(): WC_Straumur_API {
-		if ( is_null( self::$instance ) ) {
-			self::$instance = new self();
-		}
-		return self::$instance;
-	}
 
 	/**
 	 * Constructor.

--- a/includes/class-wc-straumur-payment-gateway.php
+++ b/includes/class-wc-straumur-payment-gateway.php
@@ -97,9 +97,6 @@ class WC_Straumur_Payment_Gateway extends WC_Payment_Gateway {
 	 * @return string HTML string containing the payment method icons.
 	 */
 	public function get_icon(): string {
-		// Get the default icon from the parent method.
-		$default_icon_html = parent::get_icon();
-
 		// Define custom card logos.
 		$card_logos = array(
 			'visa' => STRAUMUR_PAYMENTS_PLUGIN_URL . 'assets/images/visa-logo.png',

--- a/includes/class-wc-straumur-settings.php
+++ b/includes/class-wc-straumur-settings.php
@@ -2,7 +2,7 @@
 /**
  * Straumur Settings Class
  *
- * Provides and validates the settings fields used by the Straumur payment gateway.dsd
+ * Provides and validates the settings fields used by the Straumur payment gateway.
  *
  * @package Straumur\Payments
  * @since   1.0.0

--- a/includes/class-wc-straumur-webhook-handler.php
+++ b/includes/class-wc-straumur-webhook-handler.php
@@ -1092,6 +1092,3 @@ class WC_Straumur_Webhook_Handler
 		}
 	}
 }
-
-// Initialize the handler.
-WC_Straumur_Webhook_Handler::init();

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const settings = getSetting( 'straumur_data', {} );
 
 const defaultLabel = __(
     'Straumur Payments',
-    'woo-gutenberg-products-block'
+    'straumur-payments-for-woocommerce'
 );
 
 const label = decodeEntities( settings.title ) || defaultLabel;

--- a/straumur-payments-for-woocommerce.php
+++ b/straumur-payments-for-woocommerce.php
@@ -47,7 +47,7 @@ define('STRAUMUR_PAYMENTS_PLUGIN_URL', plugin_dir_url(__FILE__));
  * @since 1.0.0
  * @return void
  */
-function straumur_payments_woocommerce_missing_notice(): void
+function straumur_missing_notice(): void
 {
 	if (! current_user_can('activate_plugins')) {
 		return;
@@ -156,11 +156,11 @@ function straumur_filter_customer_payment_tokens($tokens, $customer_id)
  * @since 1.0.0
  * @return void
  */
-function straumur_payments_init(): void
+function straumur_init(): void
 {
 	// Check if WooCommerce is active.
 	if (! function_exists('WC')) {
-		add_action('admin_notices', __NAMESPACE__ . '\\straumur_payments_woocommerce_missing_notice');
+		add_action('admin_notices', __NAMESPACE__ . '\\straumur_missing_notice');
 		return;
 	}
 
@@ -178,6 +178,8 @@ function straumur_payments_init(): void
 	require_once STRAUMUR_PAYMENTS_PLUGIN_DIR . 'includes/class-wc-straumur-payment-gateway.php';
 	require_once STRAUMUR_PAYMENTS_PLUGIN_DIR . 'includes/class-wc-straumur-block-support.php';
 	require_once STRAUMUR_PAYMENTS_PLUGIN_DIR . 'includes/class-wc-straumur-webhook-handler.php';
+	// Initialize the webhook handler.
+	WC_Straumur_Webhook_Handler::init();
 
 	// Register block-based checkout integrations if available.
 	if (class_exists(__NAMESPACE__ . '\\WC_Straumur_Block_Support')) {
@@ -235,11 +237,11 @@ function straumur_payments_init(): void
 	// Add plugin action links.
 	add_filter(
 		'plugin_action_links_' . plugin_basename(STRAUMUR_PAYMENTS_MAIN_FILE),
-		__NAMESPACE__ . '\\straumur_payments_action_links'
+		__NAMESPACE__ . '\\straumur_action_links'
 	);
 
 	// Add plugin row meta.
-	add_filter('plugin_row_meta', __NAMESPACE__ . '\\straumur_payments_plugin_row_meta', 10, 2);
+	add_filter('plugin_row_meta', __NAMESPACE__ . '\\straumur_plugin_row_meta', 10, 2);
 
 	// Instantiate the order handler (manages captures, refunds, cancellations).
 	$straumur_order_handler = new WC_Straumur_Order_Handler();
@@ -323,7 +325,7 @@ function add_straumur_payment_gateway(array $gateways): array
  * @param array $links Existing plugin action links.
  * @return array Modified plugin action links.
  */
-function straumur_payments_action_links(array $links): array
+function straumur_action_links(array $links): array
 {
 	$settings_url  = admin_url('admin.php?page=wc-settings&tab=checkout&section=straumur');
 	$settings_link = sprintf(
@@ -345,7 +347,7 @@ function straumur_payments_action_links(array $links): array
  * @param string $file  Plugin file path.
  * @return array Modified plugin meta links.
  */
-function straumur_payments_plugin_row_meta(array $links, string $file): array
+function straumur_plugin_row_meta(array $links, string $file): array
 {
 	if (plugin_basename(STRAUMUR_PAYMENTS_MAIN_FILE) === $file) {
 		$docs_link    = '<a href="https://docs.straumur.is" target="_blank" rel="noopener noreferrer">' .
@@ -362,4 +364,4 @@ function straumur_payments_plugin_row_meta(array $links, string $file): array
 
 
 // Initialize the plugin after all plugins are loaded, ensuring WooCommerce is ready.
-add_action('plugins_loaded', __NAMESPACE__ . '\\straumur_payments_init');
+add_action('plugins_loaded', __NAMESPACE__ . '\\straumur_init');


### PR DESCRIPTION
## Summary

Code quality fixes identified during codebase health review.

### Changes

- **Fix docblock typo** — remove stray `dsd` from settings class docblock
- **Fix text domain** in `src/index.js` — was `woo-gutenberg-products-block`, now correctly `straumur-payments-for-woocommerce`
- **Remove dead code** in `get_icon()` — `$default_icon_html` was assigned but never used
- **Remove unused singleton** from `WC_Straumur_API` — `static $instance` and `instance()` were never called; the class is always instantiated directly with `new`
- **Apply PR#38 refactor** (closes #38) — remove redundant `straumur_payments_` prefix from namespace-scoped functions
- **Move `WC_Straumur_Webhook_Handler::init()`** from the bottom of the class file to the main plugin bootstrap, which is the correct place for side effects