### PR TITLE
Bump version to 2.0.4, update WP/WC compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: smartmediais, straumur
 Tags: woocommerce, payments, straumur, subscriptions
 Requires at least: 5.2
-Tested up to: 6.8
+Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.0.3
+Stable tag: 2.0.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -84,6 +84,10 @@ All credentials available at [https://thjonustuvefur.straumur.is/](https://thjon
 
 
 == Changelog ==
+= 2.0.4 =
+* Tested with WordPress 6.9
+* Tested with WooCommerce 10.7
+
 = 2.0.3 =
 * Update payment method icons to display VISA, Mastercard, Google Pay, and Apple Pay logos
 * Improve payment method visual identification for customers

--- a/straumur-payments-for-woocommerce.php
+++ b/straumur-payments-for-woocommerce.php
@@ -8,10 +8,10 @@
  * Author URI:      https://straumur.is
  * Text Domain:     straumur-payments-for-woocommerce
  * Domain Path:     /languages
- * Version:         2.0.3
+ * Version:         2.0.4
  * Requires Plugins: woocommerce
  * WC requires at least: 8.1
- * WC tested up to: 9.9
+ * WC tested up to: 10.7
  * WC Payment Gateway: yes
  * WC Subscriptions Support: yes
  * WC Blocks Support: yes
@@ -34,9 +34,9 @@ if (! defined('ABSPATH')) {
 
 /*
  * Define plugin constants.
- * Previous version: 2.0.2
+ * Previous version: 2.0.3
  */
-define('STRAUMUR_PAYMENTS_VERSION', '2.0.3');
+define('STRAUMUR_PAYMENTS_VERSION', '2.0.4');
 define('STRAUMUR_PAYMENTS_MAIN_FILE', __FILE__);
 define('STRAUMUR_PAYMENTS_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('STRAUMUR_PAYMENTS_PLUGIN_URL', plugin_dir_url(__FILE__));


### PR DESCRIPTION
## Changes

- **Version**: `2.0.3` → `2.0.4`
- **WordPress tested up to**: `6.8` → `6.9`
- **WooCommerce tested up to**: `9.9` → `10.7`
- Changelog entry added for `2.0.4`