### PR TITLE
fix: correctly remove straumur_payments_ prefix from function names

### DIFF
--- a/straumur-payments-for-woocommerce.php
+++ b/straumur-payments-for-woocommerce.php
@@ -47,7 +47,7 @@ define('STRAUMUR_PAYMENTS_PLUGIN_URL', plugin_dir_url(__FILE__));
  * @since 1.0.0
  * @return void
  */
-function straumur_missing_notice(): void
+function woocommerce_missing_notice(): void
 {
 	if (! current_user_can('activate_plugins')) {
 		return;
@@ -156,11 +156,11 @@ function straumur_filter_customer_payment_tokens($tokens, $customer_id)
  * @since 1.0.0
  * @return void
  */
-function straumur_init(): void
+function init(): void
 {
 	// Check if WooCommerce is active.
 	if (! function_exists('WC')) {
-		add_action('admin_notices', __NAMESPACE__ . '\\straumur_missing_notice');
+		add_action('admin_notices', __NAMESPACE__ . '\\woocommerce_missing_notice');
 		return;
 	}
 
@@ -237,11 +237,11 @@ function straumur_init(): void
 	// Add plugin action links.
 	add_filter(
 		'plugin_action_links_' . plugin_basename(STRAUMUR_PAYMENTS_MAIN_FILE),
-		__NAMESPACE__ . '\\straumur_action_links'
+		__NAMESPACE__ . '\\action_links'
 	);
 
 	// Add plugin row meta.
-	add_filter('plugin_row_meta', __NAMESPACE__ . '\\straumur_plugin_row_meta', 10, 2);
+	add_filter('plugin_row_meta', __NAMESPACE__ . '\\plugin_row_meta', 10, 2);
 
 	// Instantiate the order handler (manages captures, refunds, cancellations).
 	$straumur_order_handler = new WC_Straumur_Order_Handler();
@@ -325,7 +325,7 @@ function add_straumur_payment_gateway(array $gateways): array
  * @param array $links Existing plugin action links.
  * @return array Modified plugin action links.
  */
-function straumur_action_links(array $links): array
+function action_links(array $links): array
 {
 	$settings_url  = admin_url('admin.php?page=wc-settings&tab=checkout&section=straumur');
 	$settings_link = sprintf(
@@ -347,7 +347,7 @@ function straumur_action_links(array $links): array
  * @param string $file  Plugin file path.
  * @return array Modified plugin meta links.
  */
-function straumur_plugin_row_meta(array $links, string $file): array
+function plugin_row_meta(array $links, string $file): array
 {
 	if (plugin_basename(STRAUMUR_PAYMENTS_MAIN_FILE) === $file) {
 		$docs_link    = '<a href="https://docs.straumur.is" target="_blank" rel="noopener noreferrer">' .
@@ -364,4 +364,4 @@ function straumur_plugin_row_meta(array $links, string $file): array
 
 
 // Initialize the plugin after all plugins are loaded, ensuring WooCommerce is ready.
-add_action('plugins_loaded', __NAMESPACE__ . '\\straumur_init');
+add_action('plugins_loaded', __NAMESPACE__ . '\\init');


### PR DESCRIPTION
The previous refactor (#60, applying PR#38) only stripped `payments_` from function names instead of the full `straumur_payments_` prefix. Since all these functions live in the `Straumur\Payments` namespace, the prefix is entirely redundant.

## Changes

| Before (wrong) | After (correct) |
|---|---|
| `straumur_woocommerce_missing_notice` | `woocommerce_missing_notice` |
| `straumur_init` | `init` |
| `straumur_action_links` | `action_links` |
| `straumur_plugin_row_meta` | `plugin_row_meta` |

This addresses the follow-up feedback from @szepeviktor in PR#38 who noted the `straumur_` prefix was still present after the manual application.