### PR TITLE
Fix PHP syntax error in block support icons array

### DIFF
--- a/includes/class-wc-straumur-block-support.php
+++ b/includes/class-wc-straumur-block-support.php
@@ -72,7 +72,6 @@ class WC_Straumur_Block_Support extends AbstractPaymentMethodType {
 				'googlepay'  => esc_url( STRAUMUR_PAYMENTS_PLUGIN_URL . 'assets/images/googlepay.png' ),
 				'applepay'   => esc_url( STRAUMUR_PAYMENTS_PLUGIN_URL . 'assets/images/applepay.png' ),
 			),
-			),
 		);
 	}
 


### PR DESCRIPTION
The merge of PR #73 introduced a duplicate closing parenthesis in `get_payment_method_data()` which causes a PHP fatal error, taking down wp-admin entirely.

This removes the extra `)` to restore valid PHP syntax.