### PR TITLE
Show the Straumur logo on the payments settings screen

### DIFF
--- a/includes/class-wc-straumur-payment-gateway.php
+++ b/includes/class-wc-straumur-payment-gateway.php
@@ -57,7 +57,7 @@ class WC_Straumur_Payment_Gateway extends WC_Payment_Gateway {
 		$this->method_title       = esc_html__( 'Straumur Payments', 'straumur-payments-for-woocommerce' );
 		$this->method_description = esc_html__( 'Accept payments via Straumur Hosted Checkout.', 'straumur-payments-for-woocommerce' );
 		$this->has_fields         = false;
-		$this->icon               = ''; // Icons are handled by custom get_icon() method
+		$this->icon               = STRAUMUR_PAYMENTS_PLUGIN_URL . 'assets/images/straumur-128x128.png';
 
 		$this->supports = array(
 			'products',


### PR DESCRIPTION
The gateway icon property was empty, so no logo appeared next to Straumur Payments in the WooCommerce payment methods list. Point it at the bundled 128x128 logo. Checkout is unaffected since get_icon() renders the card brand logos there.