### PR TITLE
Stop advertising subscription payment method changes

### DIFF
--- a/includes/class-wc-straumur-payment-gateway.php
+++ b/includes/class-wc-straumur-payment-gateway.php
@@ -68,8 +68,6 @@ class WC_Straumur_Payment_Gateway extends WC_Payment_Gateway {
 			'subscription_suspension',
 			'subscription_reactivation',
 			'subscription_amount_changes',
-			'subscription_payment_method_change_customer',
-			'subscription_payment_method_change_admin',
 			'subscription_date_changes',
 			'multiple_subscriptions',
 		);
@@ -81,7 +79,6 @@ class WC_Straumur_Payment_Gateway extends WC_Payment_Gateway {
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 
 		add_action( 'woocommerce_scheduled_subscription_payment_straumur', array( $this, 'process_subscription_payment' ), 10, 2 );
-		add_action( 'woocommerce_subscription_payment_method_updated_to_straumur', array( $this, 'process_subscription_payment_method_change' ) );
 		
 		// Enqueue frontend styles
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_styles' ) );


### PR DESCRIPTION
The gateway declared subscription_payment_method_change_customer and _admin support and hooked woocommerce_subscription_payment_method_updated_to_straumur, but process_subscription_payment_method_change() was never implemented. That offered customers a "change payment method" option that fatals when used. Remove the unimplemented support flags and the dead hook until the flow is built properly.